### PR TITLE
retention_policy can be specified in configuration and used by client

### DIFF
--- a/lib/influxdb/rails/configuration.rb
+++ b/lib/influxdb/rails/configuration.rb
@@ -29,19 +29,20 @@ module InfluxDB
       include Configurable
 
       set_defaults(
-        hosts:          ["localhost"].freeze,
-        port:           8086,
-        username:       "root".freeze,
-        password:       "root".freeze,
-        database:       nil,
-        auth_method:    "params".freeze,
-        async:          true,
-        use_ssl:        false,
-        retry:          nil,
-        open_timeout:   5,
-        read_timeout:   300,
-        max_delay:      30,
-        time_precision: "s".freeze
+        hosts:            ["localhost"].freeze,
+        port:             8086,
+        username:         "root".freeze,
+        password:         "root".freeze,
+        database:         nil,
+        auth_method:      "params".freeze,
+        async:            true,
+        use_ssl:          false,
+        retry:            nil,
+        open_timeout:     5,
+        read_timeout:     300,
+        max_delay:        30,
+        time_precision:   "s".freeze,
+        retention_policy: nil
       )
 
       def initialize

--- a/lib/influxdb/rails/configuration.rb
+++ b/lib/influxdb/rails/configuration.rb
@@ -98,7 +98,8 @@ module InfluxDB
         :open_timeout,
         :read_timeout,
         :max_delay,
-        :time_precision
+        :time_precision,
+        :retention_policy
 
       def initialize
         @client = ClientConfig.new

--- a/lib/influxdb/rails/metric.rb
+++ b/lib/influxdb/rails/metric.rb
@@ -12,24 +12,33 @@ module InfluxDB
       end
 
       def write
-        client.write_point(
-          configuration.measurement_name,
-          options,
-          configuration.client.time_precision,
-          configuration.client.retention_policy
-        )
+        client.write_point(*write_point_arguments)
       end
 
       private
 
       attr_reader :configuration, :tags, :values, :timestamp
 
+      def write_point_arguments
+        arguments = [configuration.measurement_name, options]
+
+        if configuration.client.retention_policy.present?
+          arguments.push(nil, configuration.client.retention_policy)
+        end
+
+        arguments
+      end
+
       def options
         {
           values:    Values.new(values: values).to_h,
           tags:      Tags.new(tags: tags, config: configuration).to_h,
-          timestamp: timestamp.utc.to_i,
+          timestamp: timestamp_with_precision,
         }
+      end
+
+      def timestamp_with_precision
+        InfluxDB.convert_timestamp(timestamp.utc, configuration.client.time_precision)
       end
 
       def client

--- a/lib/influxdb/rails/metric.rb
+++ b/lib/influxdb/rails/metric.rb
@@ -12,7 +12,12 @@ module InfluxDB
       end
 
       def write
-        client.write_point configuration.measurement_name, options
+        client.write_point(
+          configuration.measurement_name,
+          options,
+          configuration.client.time_precision,
+          configuration.client.retention_policy
+        )
       end
 
       private
@@ -23,12 +28,8 @@ module InfluxDB
         {
           values:    Values.new(values: values).to_h,
           tags:      Tags.new(tags: tags, config: configuration).to_h,
-          timestamp: timestamp_with_precision,
+          timestamp: timestamp.utc.to_i,
         }
-      end
-
-      def timestamp_with_precision
-        InfluxDB.convert_timestamp(timestamp.utc, configuration.client.time_precision)
       end
 
       def client

--- a/lib/influxdb/rails/test_client.rb
+++ b/lib/influxdb/rails/test_client.rb
@@ -5,7 +5,7 @@ module InfluxDB
         []
       end
 
-      def write_point(name, options = {})
+      def write_point(name, options = {}, _time_precision = nil, _retention_policy = nil)
         metrics << options.merge(name: name)
       end
     end

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -72,6 +72,19 @@ RSpec.describe InfluxDB::Rails::Configuration do
         expect(subject.time_precision).to eql("ms")
       end
     end
+
+    describe "#retention_policy" do
+      it "defaults to nil" do
+        expect(subject.retention_policy).to eql(nil)
+      end
+
+      it "can be updated" do
+        InfluxDB::Rails.configure do |config|
+          config.client.retention_policy = "one_month"
+        end
+        expect(subject.retention_policy).to eql("one_month")
+      end
+    end
   end
 
   describe "#rails_app_name" do

--- a/spec/unit/metric_spec.rb
+++ b/spec/unit/metric_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+RSpec.describe InfluxDB::Rails::Metric do
+  let(:config) { InfluxDB::Rails::Configuration.new }
+  let(:timestamp) { Time.zone.now }
+  let(:metric) do
+    InfluxDB::Rails::Metric.new(configuration: config, timestamp: timestamp, values: { a: 1 })
+  end
+  let(:client) { instance_double("client", write_point: nil) }
+
+  before do
+    allow(metric).to receive(:client) { client }
+  end
+
+  describe "without retention_policy specified" do
+    it "push the metrics correctly" do
+      metric.write
+      data = { values: { a: 1 }, timestamp: timestamp.utc.to_i }
+      expect(client).to have_received(:write_point)
+        .with(config.measurement_name, a_hash_including(data), config.client.time_precision, nil)
+    end
+  end
+
+  describe "with retention_policy specified" do
+    before { config.client.retention_policy = "fancy_policy" }
+
+    it "push the metrics correctly" do
+      metric.write
+      data = { values: { a: 1 }, timestamp: timestamp.utc.to_i }
+      expect(client).to have_received(:write_point)
+        .with(config.measurement_name, a_hash_including(data), config.client.time_precision, "fancy_policy")
+    end
+  end
+end

--- a/spec/unit/metric_spec.rb
+++ b/spec/unit/metric_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe InfluxDB::Rails::Metric do
       metric.write
       data = { values: { a: 1 }, timestamp: timestamp.utc.to_i }
       expect(client).to have_received(:write_point)
-        .with(config.measurement_name, a_hash_including(data), config.client.time_precision, nil)
+        .with(config.measurement_name, a_hash_including(data))
     end
   end
 
@@ -28,7 +28,7 @@ RSpec.describe InfluxDB::Rails::Metric do
       metric.write
       data = { values: { a: 1 }, timestamp: timestamp.utc.to_i }
       expect(client).to have_received(:write_point)
-        .with(config.measurement_name, a_hash_including(data), config.client.time_precision, "fancy_policy")
+        .with(config.measurement_name, a_hash_including(data), nil, "fancy_policy")
     end
   end
 end


### PR DESCRIPTION
Ho aggiunto al push delle metriche la retention_policy che può essere impostata nella configurazione della gemma, per fare ciò ho aggiunto alla chiamata della funzione `write_point` il parametro `time_precision` perché sono parametri posizionali e l'ultimo è quello della `retention_policy`.
Dopo aver aggiunto la precisione del tempo ho tolto il metodo `timestamp_with_precision` perché lo fa già internamente la libreria `influxdb-ruby`, indicando appunto il parametro `time_precision`, al momento del push dei dati.
> tenere il `timestamp_with_precision` e passare `nil` al metodo per il parametro posizionale potrebbe rompere tutto visto che se il parametro è nil viene preso di default "s" (secondi) e quindi se nella configurazione è impostata una certa precisione diversa da "s" ci sarebbe un incongruenza dei dati passati